### PR TITLE
Add filter by technology to profiles

### DIFF
--- a/src/Profiles/Profiles.scss
+++ b/src/Profiles/Profiles.scss
@@ -1,4 +1,49 @@
-.container {
+.results-filter {
+  display: flex;
+  align-items: center;
+  margin: 20px auto;
+
+  > p {
+    color: grey;
+    font-size: 18px;
+  }
+}
+
+.results-dropdown {
+  position: relative;
+
+  > select {
+    appearance: none;
+    background: white;
+    border: 1.5px solid lightgrey;
+    border-radius: 4px;
+    color: gray;
+    cursor: pointer;
+    line-height: 1.5;
+    font-size: 16px;
+    margin-left: 10px;
+    outline: none;
+    padding: 5px 20px 5px 10px;
+    transition: border 250ms ease;
+    width: 100%;
+
+    &:hover, &:focus {
+      border-color: #7b8acc;
+    }
+  }
+
+  &::after {
+    color: #7b8acc;
+    content: '▼';
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    right: 0px;
+    font-size: 9px;
+  }
+}
+
+.results-container {
   display: grid;
   grid-gap: 10px;
   grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));

--- a/src/Profiles/index.js
+++ b/src/Profiles/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react"
+import React, { Component, Fragment } from "react"
 import data from '../data.json'
 import Card from "../Card"
 import "./Profiles.scss"
@@ -7,7 +7,9 @@ class Profiles extends Component {
   constructor() {
     super()
     this.state = {
-      people: []
+      people: [],
+      tags: [],
+      selectedTag: '',
     }
   }
 
@@ -15,26 +17,53 @@ class Profiles extends Component {
     let a = [...data]
     var j, x, i
     for (i = a.length - 1; i > 0; i--) {
-        j = Math.floor(Math.random() * (i + 1))
-        x = a[i]
-        a[i] = a[j]
-        a[j] = x
+      j = Math.floor(Math.random() * (i + 1))
+      x = a[i]
+      a[i] = a[j]
+      a[j] = x
     }
     return a
+  }
+
+  getTags(people) {
+    const tags = people.map(person => person.fields.Tags);
+    const mergedTags = tags.reduce((a, b) => [...a, ...b], []);
+    const uniqueArrayOfTags = Array.from(new Set([...mergedTags])).sort((a, b) => a < b ? -1 : 1);;
+    this.setState({
+      tags: uniqueArrayOfTags,
+    });
+  }
+
+  handleChange = (e) => {
+    this.setState({ selectedTag: e.target.value });
   }
 
   componentDidMount() {
     let shuffledData = this.shuffle(data)
     this.setState({
       people: shuffledData
-    })
+    }, () => this.getTags(this.state.people));
   }
 
   render() {
-    return ( 
-      <div className="container">
-        {this.state.people.map(person => <Card key={person.id} person={person} data-tip={person.Name}/>)}
-      </div>
+    const { people, tags, selectedTag } = this.state;
+    const filteredPeople = people.filter(person => person.fields.Tags.includes(selectedTag));
+    const peopleToMap = selectedTag ? filteredPeople : people;
+    return (
+      <Fragment>
+        <div className="results-filter">
+          <p>Filter by technology</p>
+          <div className="results-dropdown">
+            <select onChange={this.handleChange} value={selectedTag}>
+              <option value="">Choose a filter</option>
+              {tags.map(tag => <option value={tag} key={tag}>{tag}</option>)}
+            </select>
+          </div>
+        </div>
+        <div className="results-container">
+          {peopleToMap.map(person => <Card key={person.id} person={person} data-tip={person.Name} />)}
+        </div>
+      </Fragment>
     )
   }
 }


### PR DESCRIPTION
Resolves #4 

This PR adds in the ability to filter people by their technology tags. It's set up to map through all the people and get a list of unique tags, so that way if you add more people with different tags you shouldn't have to change any code. Super simple styling to match what is existing already.