### PR TITLE
Increased header h1 to 32px, reduce header h4 and header a to 17px fo…

### DIFF
--- a/src/Header/Header.scss
+++ b/src/Header/Header.scss
@@ -4,8 +4,8 @@ header {
 
   h1 {
     font-family: 'Playfair Display', serif;
-    font-weight: 400;
-    font-size: 25px;
+    font-weight: 600;
+    font-size: 32px;
     margin-bottom: 0px;
   }
 
@@ -20,10 +20,11 @@ header {
     margin-top: 5px;
     font-family: Roboto,sans-serif;
     margin-bottom: 5px;
+    font-size: 17px;
   }
 
   .about-link {
     color: #7b8acc;
-    font-size: 20px;
+    font-size: 17px;
   }
 }


### PR DESCRIPTION
Increased header h1 to 32px, reduce header h4 and header a to 17px for better heading visual

## Motivation and Context
Below thumbnails had the heading font size of 32px.

## How Has This Been Tested?
It was tested locally by running npm start

## Screenshots (if appropriate):
![untitled](https://user-images.githubusercontent.com/15031868/47740941-13820900-dc9f-11e8-9cd2-416de1dc10e3.png)

## Types of changes
1. header h1 - font-size: 32px, font-weight: 600
2. header h4 - font-size: 17px
3. header a - font-size: 17px
