### PR TITLE
adding default avatar image

### DIFF
--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -18,7 +18,7 @@ const Card = props => {
       {project.Image && (
         <div class="profileImageContainer">
           <img
-            src={project.Image[0].thumbnails.large.url}
+            src={project.Image[0].thumbnails.large.url ? project.Image[0].thumbnails.large.url : 'https://api.adorable.io/avatars/285/learn-code-from-us-default-avtr.png'}
             alt={"Picture of " + project.Name}
             className="profileImage"
           />


### PR DESCRIPTION
## Description
I just add ternary operator to the img tag source. If it have `project.Image[0].thumbnails.large.url` then load it. If it doesn't then load the default avatar that is a service from adorable avatar. maybe its too cute?

## Motivation and Context
I wrote this PR because Im motivated to fix the issue number #71 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
