### PR TITLE
Route to Home from About (toggle)

### DIFF
--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -16,7 +16,7 @@ const Card = props => {
     <div className="content">
       <h2>{project.Name}</h2>
       {project.Image && (
-        <div class="profileImageContainer">
+        <div className="profileImageContainer">
           <img
             src={project.Image[0].thumbnails.large.url}
             alt={"Picture of " + project.Name}

--- a/src/Header/Header.scss
+++ b/src/Header/Header.scss
@@ -23,7 +23,7 @@ header {
     font-size: 17px;
   }
 
-  .about-link {
+  .link {
     color: #7b8acc;
     font-size: 17px;
   }

--- a/src/Header/index.js
+++ b/src/Header/index.js
@@ -4,14 +4,15 @@ import './Header.scss'
 
 const Header = props => {
 
-  const ifCurrentPageIsHome = () => {
+  // If current page is home, return true.
+  const isCurrentPageHome = () => {
     const pages = window.location.href.split('/');
     const currentPage = pages[pages.length-1];
     return currentPage === '';
   }
 
   const aboutLink = (<Link to='/about' className='link'> About this Site </Link>);
-  const homeLink = (<Link to='/' className='link'> Return to Dasbboard </Link>);
+  const homeLink = (<Link to='/' className='link'> Return to Home </Link>);
 
   return (
     <header>
@@ -23,7 +24,7 @@ const Header = props => {
         programming resources
       </h4>
       {
-        ifCurrentPageIsHome() ? aboutLink : homeLink
+        isCurrentPageHome() ? aboutLink : homeLink
       } 
     </header>
   )

--- a/src/Header/index.js
+++ b/src/Header/index.js
@@ -3,6 +3,16 @@ import Link from '../Link'
 import './Header.scss'
 
 const Header = props => {
+
+  const ifCurrentPageIsHome = () => {
+    const pages = window.location.href.split('/');
+    const currentPage = pages[pages.length-1];
+    return currentPage === '';
+  }
+
+  const aboutLink = (<Link to='/about' className='link'> About this Site </Link>);
+  const homeLink = (<Link to='/' className='link'> Return to Dasbboard </Link>);
+
   return (
     <header>
       <h1>
@@ -12,9 +22,9 @@ const Header = props => {
         People from underrepresented groups in tech who create awesome
         programming resources
       </h4>
-      <Link to='/about' className='about-link'>
-        About this Site
-      </Link>
+      {
+        ifCurrentPageIsHome() ? aboutLink : homeLink
+      } 
     </header>
   )
 }


### PR DESCRIPTION
## Description
Link under description now simply toggles between About and Home depending on location, giving a more intuitive way to route from About back to Home. Also, the profileImageContainer div under the Card object had a 'class' instead of 'className,' simply corrected this typo.

## Motivation and Context
After using the site, I noticed I found myself in the About page without any intuitive way to go back to the homepage. After looking at the code I realized that the title was a link back to home, this PR just serves a more intuitive way to do so.

## How Has This Been Tested?
Built and ran changes locally. All use cases run as expected.

## Screenshots (if appropriate):
![link](https://user-images.githubusercontent.com/13784628/47959444-a70a5100-dfa1-11e8-8956-ba4d6b8b31e7.gif)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
