### PR TITLE
Fix className warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
   "eslintConfig": {
     "extends": "react-app",
     "rules": {
-      "eqeqeq": 1
+      "eqeqeq": 1,
+      "semi": [
+        "error",
+        "never"
+      ]
     }
   },
   "browserslist": [

--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -17,7 +17,7 @@ const Card = props => {
       <div className="content">
         <h2>{project.Name}</h2>
         {project.Image && (
-          <div class="profileImageContainer">
+          <div className="profileImageContainer">
             <img
               src={project.Image[0].thumbnails.large.url}
               alt={project.Name}

--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -1,81 +1,81 @@
 import React from "react"
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
-import PropTypes from 'prop-types'
-import SiteLink from '../SiteLink'
-import './Card.scss'
+import ReactCSSTransitionGroup from "react-addons-css-transition-group"
+import PropTypes from "prop-types"
+import SiteLink from "../SiteLink"
+import "./Card.scss"
 
 const Card = props => {
-  let project = props.person.fields;
+  let project = props.person.fields
   return (
     <ReactCSSTransitionGroup
       transitionName="slideUp"
-      transitionAppear={true}
+      transitionAppear
       transitionAppearTimeout={2000}
       transitionEnter={false}
-      transitionLeave={false}>
-    <div className="content">
-      <h2>{project.Name}</h2>
-      {project.Image && (
-        <div class="profileImageContainer">
-          <img
-            src={project.Image[0].thumbnails.large.url}
-            alt={"Picture of " + project.Name}
-            className="profileImage"
+      transitionLeave={false}
+    >
+      <div className="content">
+        <h2>{project.Name}</h2>
+        {project.Image && (
+          <div class="profileImageContainer">
+            <img
+              src={project.Image[0].thumbnails.large.url}
+              alt={project.Name}
+              className="profileImage"
+            />
+          </div>
+        )}
+        <div className="links">
+          <SiteLink
+            icon="fas fa-pencil-alt"
+            title="Read our blog"
+            link={project.Blog}
+            tooltipText="blog"
+          />
+          <SiteLink
+            icon="fas fa-envelope"
+            title="sign up for our newsletter"
+            link={project.Newsletter}
+            tooltipText="newsletter"
+          />
+          <SiteLink
+            icon="fab fa-youtube"
+            title="subscribe to our YouTube channel"
+            link={project.YouTube}
+            tooltipText="YouTube"
+          />
+          <SiteLink
+            icon="fas fa-podcast"
+            title="subscribe to our podcast"
+            link={project.Podcast}
+            tooltipText="podcast"
+          />
+          <SiteLink
+            icon="fas fa-link"
+            title="visit our website"
+            link={project.Website}
+            tooltipText="website"
+          />
+          <SiteLink
+            icon="fab fa-dev"
+            title="read our posts on dev.to"
+            link={project.Dev}
+            tooltipText="dev.to"
           />
         </div>
-      )}
-      <div className="links">
-        <SiteLink
-          icon="fas fa-pencil-alt"
-          title="Read our blog"
-          link={project.Blog}
-          tooltipText="blog"
-        />
-        <SiteLink
-          icon="fas fa-envelope"
-          title="sign up for our newsletter"
-          link={project.Newsletter}
-          tooltipText="newsletter"
-        />
-        <SiteLink
-          icon="fab fa-youtube"
-          title="subscribe to our YouTube channel"
-          link={project.YouTube}
-          tooltipText="YouTube"
-        />
-        <SiteLink
-          icon="fas fa-podcast"
-          title="subscribe to our podcast"
-          link={project.Podcast}
-          tooltipText="podcast"
-        />
-        <SiteLink
-          icon="fas fa-link"
-          title="visit our website"
-          link={project.Website}
-          tooltipText="website"
-        />
-        <SiteLink
-          icon="fab fa-dev"
-          title="read our posts on dev.to"
-          link={project.Dev}
-          tooltipText="dev.to"
-        />
-      </div>
-      <h3>{project.About}</h3>
-      <div className='tags'>
-        {project.Tags &&
-          project.Tags.map(tag => (
-            <div key={tag} className='tag'>
-              {tag}
-            </div>
-          ))}
-      </div>
+        <h3>{project.About}</h3>
+        <div className="tags">
+          {project.Tags &&
+            project.Tags.map(tag => (
+              <div key={tag} className="tag">
+                {tag}
+              </div>
+            ))}
+        </div>
       </div>
     </ReactCSSTransitionGroup>
   )
 }
-
 
 Card.propTypes = {
   person: PropTypes.shape({


### PR DESCRIPTION
## Description
This aims at fixing the `className` warning that pops up when running the tests, and collaterally changes code organisation in the relevant file.
I also noted that we're not using semicolons and added a rule to the aslant config.
As always, if these reorganisations break any code style already stablished, let me know so I can rollback any infractions.

## Motivation and Context

This warning:
<img width="613" alt="screen shot 2018-12-18 at 08 45 17" src="https://user-images.githubusercontent.com/4389850/50149392-3776c980-02a2-11e9-8597-4dad1be08e06.png">

## How Has This Been Tested?
One could argue that, since this is a refactor, it just needs to not break any existing tests, but I've noticed this particular component isn't really well tested. A nice contribution in the future would be to test it so we can guarantee no regressions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the code style of this project.
> I mean, I'm not really sure. I think I'll need a nudge in the right direction here.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
> In fact, it removes one.